### PR TITLE
Makefile: create both deft exe symlink deft-app for back compat

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -46,7 +46,7 @@ jobs:
           DYLAN_CATALOG: ext/pacman-catalog
           DYLAN: dylan-root
         run: |
-          exe="$(realpath ${DYLAN}/bin/deft-app)"
+          exe="$(realpath ${DYLAN}/bin/deft)"
           export DYLAN_CATALOG="$(realpath ${DYLAN_CATALOG})"
           ${exe} new library --force-package abc strings@1.1
           cd abc

--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,12 @@ build-with-version: remove-deft-artifacts
 	    dylan-compiler -build -unify deft-app; \
 	  cp -p $${orig} $${file}
 
+# Until the install-deft GitHub Action is no longer referring to deft-app
+# we also create a link named deft-app.
 really-install:
 	mkdir -p $(DYLAN)/bin
-	cp _build/sbin/deft-app $(DYLAN)/bin/
+	cp _build/sbin/deft-app $(DYLAN)/bin/deft
+	ln -f $(DYLAN)/bin/deft $(DYLAN)/bin/deft-app
 
 install: build-with-version really-install
 


### PR DESCRIPTION
Some GitHub workflows expect the exe to be named "deft" (as it should be) rather than "deft-app" (as it is). Fix it and leave a symlink to be backward compatible.

(It was a bug that it was installed as `deft-app`. I suspect I didn't notice it when it was installed as `dylan-tool-app` because the `dylan` exe was installed with Open Dylan so the workflows found that instead.)